### PR TITLE
Hotfix - add "comment_id" in response 'POST /api/comment/'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
-
+backend/coverage.xml
 # nyc test coverage
 .nyc_output
 

--- a/backend/comment/models.py
+++ b/backend/comment/models.py
@@ -24,7 +24,9 @@ class Comment(models.Model):
         options = self._meta
         data = {}
         for f in chain(options.concrete_fields):
-            if f.name == "content":
+            if f.name == "id":
+                data["comment_id"] = f.value_from_object(self)
+            elif f.name == "content":
                 data[f.name] = f.value_from_object(self)
             elif f.name == "author":
                 author = User.objects.get(id=f.value_from_object(self))


### PR DESCRIPTION
@yg-moon #36
"comment_id" 추가했음