### PR TITLE
refactor: Create/Edit Roadmap test

### DIFF
--- a/frontend/src/containers/CreateRoadmap/CreateRoadmap.test.js
+++ b/frontend/src/containers/CreateRoadmap/CreateRoadmap.test.js
@@ -73,8 +73,6 @@ describe("<CreateRoadmap />", () => {
     mount(tmpCreateRoadmap);
     expect(spyHistoryGoBack).toHaveBeenCalledTimes(1);
     expect(spyAlert).toHaveBeenCalledTimes(1);
-    spyHistoryGoBack.mockRestore();
-    spyAlert.mockRestore();
   });
 
   it("should set state on input changes", () => {
@@ -91,7 +89,7 @@ describe("<CreateRoadmap />", () => {
     wrapper = component.find("#new-tag");
     wrapper.simulate("change", { target: { value: newTag } });
     wrapper = component.find("#roadmap-private");
-    wrapper.at(2).simulate("click");
+    wrapper.at(0).props().onClick();
     wrapper = component.find("#roadmap-description");
     wrapper.simulate("change", { target: { value: description } });
     const instance = component.find(Roadmap).instance();
@@ -336,7 +334,6 @@ describe("<CreateRoadmap />", () => {
     const wrapper = component.find("#back-roadmap-button");
     wrapper.simulate("click");
     expect(spyHistoryGoBack).toHaveBeenCalledTimes(1);
-    spyHistoryGoBack.mockRestore();
   });
 
   it("should call 'onClickCreateBack' - confirm=True", () => {
@@ -348,7 +345,6 @@ describe("<CreateRoadmap />", () => {
     wrapper.simulate("click");
     expect(spyBackConfirmTrue).toHaveBeenCalledTimes(1);
     expect(spyHistoryGoBack).toHaveBeenCalledTimes(1);
-    spyHistoryGoBack.mockRestore();
   });
 
   it("should call 'onClickCreateBack' - confirm=False", () => {
@@ -360,7 +356,6 @@ describe("<CreateRoadmap />", () => {
     wrapper.simulate("click");
     expect(spyBackConfirmFalse).toHaveBeenCalledTimes(1);
     expect(spyHistoryGoBack).toHaveBeenCalledTimes(0);
-    spyHistoryGoBack.mockRestore();
   });
 
   it("should call 'onClickCreateConfirm'", () => {

--- a/frontend/src/containers/EditRoadmap/EditRoadmap.test.js
+++ b/frontend/src/containers/EditRoadmap/EditRoadmap.test.js
@@ -153,7 +153,6 @@ describe("<EditRoadmap />", () => {
     const wrapper = component.find(".EditRoadmap");
     expect(wrapper.length).toBe(0);
     expect(spyAlert).toHaveBeenCalledTimes(1);
-    spyAlert.mockRestore();
   });
 
   it("should wait if 'selectedRoadmap' has not been received", () => {
@@ -197,7 +196,6 @@ describe("<EditRoadmap />", () => {
     const wrapper = component.find(".CreateRoadmap");
     expect(wrapper.length).toBe(0);
     expect(spyAlert).toHaveBeenCalledTimes(1);
-    spyAlert.mockRestore();
   });
 
   it("should set state if selectedRoadmap has been received", () => {
@@ -229,7 +227,7 @@ describe("<EditRoadmap />", () => {
     wrapper = component.find("#new-tag");
     wrapper.simulate("change", { target: { value: newTag } });
     wrapper = component.find("#roadmap-private");
-    wrapper.at(2).simulate("click");
+    wrapper.at(0).props().onClick();
     wrapper = component.find("#roadmap-description");
     wrapper.simulate("change", { target: { value: description } });
     const instance = component.find(Roadmap).instance();


### PR DESCRIPTION
- changed the way to simulate click on material-ui components
- deleted mockRestore()

issue #68